### PR TITLE
Use Berkeley DB 4.8

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,8 +10,9 @@ compiler:
   - gcc
 
 install:
+    - sudo add-apt-repository ppa:bitcoin/bitcoin -y
     - sudo apt-get update -qq
-    - sudo apt-get install -qq libboost-dev libboost-system-dev libboost-filesystem-dev libboost-program-options-dev libboost-thread-dev libssl-dev libdb++-dev libminiupnpc-dev libqt4-dev libqrencode-dev qt4-qmake
+    - sudo apt-get install -qq libboost-dev libboost-system-dev libboost-filesystem-dev libboost-program-options-dev libboost-thread-dev libssl-dev libdb4.8-dev libdb4.8++-dev libminiupnpc-dev libqt4-dev libqrencode-dev qt4-qmake
     
 script:
     - qmake "USE_DBUS=1" "USE_QRCODE=1" "USE_UPNP=1"


### PR DESCRIPTION
Using Berkeley DB 4.8 should ensure wallet compatibility across other wallets. Unless the Windows/Mac wallets are compiled with BerkeleyDB 5 or higher, in which case ¯ \ _(ツ)_/¯.

In any case, this is the recommended build style for wallets. And if you happened to use any of the AppImage test builds, those wallets will be incompatible with this build and you will have to send any coins in those wallets to a new one.
